### PR TITLE
Added static pathing instructions to Django Style Tutorial

### DIFF
--- a/week-06/2021-07-02.md
+++ b/week-06/2021-07-02.md
@@ -187,6 +187,21 @@ body {
 }
 ```
 
+- Next, we need to point our blog/urls.py to the static `blog.css` we just created. Add the following to your `blog/urls.py`:
+```python
+from django.conf import settings # New addition to set up the static path
+from django.urls import path 
+from django.conf.urls.static import static # Allows us to define the static path with settings
+
+from . import views
+
+urlpatterns = [
+    # No changes here
+]
+
+static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) # This STATIC_URL value is set in your settings.py in your project folder.
+```
+
 - In our `post_list.html` file, we need to tell the file that we want to load some static files and will be bringing in external stylesheets:
 
 ```html


### PR DESCRIPTION
07-02 Django Styling Curriculum page needs an update for how Django static works. Add static imports and pathing to blog/urls.py  and tutorial works as advertised. Fails without.